### PR TITLE
Don't forget self in fail()  ;-)

### DIFF
--- a/openwhisk/db2.py
+++ b/openwhisk/db2.py
@@ -65,7 +65,7 @@ class DB2():
         print("%r" % temp)
 
         if len(temp) > (1048576/2)-4096:
-            fail(413, 'Too many results')
+            self.fail(413, 'Too many results')
         else:
             result = {'status': 200, 'state': 'Success', 'result': msResponse}
 


### PR DESCRIPTION
__fail()__ is an _undefined name_ in this context but __self.fail()__ is defined on line 58.

flake8 testing of https://github.com/IBM/cristata on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./openwhisk/db2.py:68:13: F821 undefined name 'fail'
            fail(413, 'Too many results')
            ^
./openwhisk/devices.py:49:18: F821 undefined name 'msg'
        result = msg.fail(400, str(e))
                 ^
2     F821 undefined name 'fail'
2
```

## Status
**GO/PAUSE/NEED REVIEW/IN DEVELOPMENT**

## Database Migrations
YES | NO

Please describe any migrations, and confirm that they adhere to the Flyway concepts.

## Description
Briefly outline the goal of the pull request.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here, for example:

```
git pull --prune
git checkout <feature_branch>
.
.
.

```
